### PR TITLE
feat(iaas): add wait functions for NAT gateways and subnets

### DIFF
--- a/iaas/constants.go
+++ b/iaas/constants.go
@@ -1,0 +1,7 @@
+package iaas
+
+import "time"
+
+var (
+	DefaultPollIntervalForWaiting = 1 * time.Second
+)

--- a/iaas/subnets.go
+++ b/iaas/subnets.go
@@ -2,7 +2,9 @@ package iaas
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/thalassa-cloud/client-go/filters"
 	"github.com/thalassa-cloud/client-go/pkg/client"
@@ -41,6 +43,12 @@ func (c *Client) ListSubnets(ctx context.Context, listRequest *ListSubnetsReques
 }
 
 // GetSubnet retrieves a specific Subnet by its identity.
+// It returns an error if the subnet is not found.
+// Example: subnet, err := c.GetSubnet(ctx, "subnet-identity1234")
+//
+//	if err != nil {
+//		log.Fatalf("Failed to get subnet: %v", err)
+//	}
 func (c *Client) GetSubnet(ctx context.Context, identity string) (*Subnet, error) {
 	var subnet *Subnet
 	req := c.R().SetResult(&subnet)
@@ -52,6 +60,90 @@ func (c *Client) GetSubnet(ctx context.Context, identity string) (*Subnet, error
 		return subnet, err
 	}
 	return subnet, nil
+}
+
+// WaitUntilSubnetDeleted waits until the subnet is deleted.
+// It returns an error if the subnet fails to delete.
+// You are responsible for providing a context that can be cancelled, and for handling the error case.
+// Example: ctxt, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+// err := c.WaitUntilSubnetDeleted(ctxt, "subnet-123")
+//
+//	if err != nil {
+//		log.Fatalf("Failed to wait for subnet to be deleted: %v", err)
+//	}
+//	defer cancel()
+func (c *Client) WaitUntilSubnetDeleted(ctx context.Context, identity string) error {
+	subnet, err := c.GetSubnet(ctx, identity)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if subnet.Status == SubnetStatusDeleted {
+		return nil
+	}
+	if subnet.Status != SubnetStatusDeleting {
+		return fmt.Errorf("subnet %s is not being deleted", identity)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(DefaultPollIntervalForWaiting):
+			subnet, err := c.GetSubnet(ctx, identity)
+			if err != nil {
+				return err
+			}
+			switch subnet.Status {
+			case SubnetStatusFailed:
+				return fmt.Errorf("subnet %s failed to delete", identity)
+			case SubnetStatusDeleted:
+				return nil
+			}
+		}
+	}
+}
+
+// WaitUntilSubnetReady waits until the subnet is ready.
+// It returns the subnet when it is ready or an error if the subnet fails to become ready. This could happen if the subnet is being deleted, or entered a failed state.
+// You are responsible for providing a context that can be cancelled, and for handling the error case.
+// Example: ctxt, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+// subnet, err := c.WaitUntilSubnetReady(ctxt, "subnet-123")
+//
+//	if err != nil {
+//		log.Fatalf("Failed to wait for subnet to become ready: %v", err)
+//	}
+//	defer cancel()
+func (c *Client) WaitUntilSubnetReady(ctx context.Context, identity string) (*Subnet, error) {
+	subnet, err := c.GetSubnet(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+	if subnet.Status == SubnetStatusReady {
+		return subnet, nil
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(DefaultPollIntervalForWaiting):
+			subnet, err := c.GetSubnet(ctx, identity)
+			if err != nil {
+				return nil, err
+			}
+			switch subnet.Status {
+			case SubnetStatusReady:
+				return subnet, nil
+			case SubnetStatusFailed:
+				return nil, fmt.Errorf("subnet %s failed to become ready", identity)
+			case SubnetStatusDeleting:
+				return nil, fmt.Errorf("subnet %s is being deleted", identity)
+			case SubnetStatusDeleted:
+				return nil, fmt.Errorf("subnet %s is deleted", identity)
+			}
+		}
+	}
 }
 
 // CreateSubnet creates a new Subnet.


### PR DESCRIPTION
- Introduced `WaitUntilNatGatewayHasEndpoint` and `WaitUntilNatGatewayDeleted` methods to manage NAT gateway lifecycle.
- Added `WaitUntilSubnetDeleted` and `WaitUntilSubnetReady` methods for subnet management.
- Introduced a new constants file with a default poll interval for waiting operations.
