### PR TITLE
feat(iaas): add labels and annotations fields to CreateMachineVolume

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ func main() {
     
     // Use the client to interact with Thalassa Cloud services
     // Example: List your vpcs
-    vpcs, err := client.IaaS().ListVpcs(ctx)
+    vpcs, err := client.IaaS().ListVpcs(ctx, &iaas.ListVpcsRequest{})
     if err != nil {
         log.Fatal(err)
     }

--- a/iaas/types.go
+++ b/iaas/types.go
@@ -421,11 +421,13 @@ type CreateMachine struct {
 }
 
 type CreateMachineVolume struct {
-	ExistingVolumeRef  *string `json:"existingVolumeRef,omitempty"`
-	VolumeTypeIdentity string  `json:"volumeTypeIdentity"`
-	Size               int     `json:"size"`
-	Name               *string `json:"name,omitempty"`
-	Description        *string `json:"description,omitempty"`
+	ExistingVolumeRef  *string     `json:"existingVolumeRef,omitempty"`
+	VolumeTypeIdentity string      `json:"volumeTypeIdentity"`
+	Size               int         `json:"size"`
+	Name               *string     `json:"name,omitempty"`
+	Description        *string     `json:"description,omitempty"`
+	Labels             Labels      `json:"labels"`
+	Annotations        Annotations `json:"annotations"`
 }
 
 type UpdateMachine struct {


### PR DESCRIPTION
This simply adds the ability to provide labels and annotations to the root volume when creating a machine.

For example:
```go
createMachine := iaas.CreateMachine{
		RootVolume: iaas.CreateMachineVolume{
			Labels: map[string]string{
				"key": "val",
			},
		},
	}
```