### PR TITLE
fix(client): protect OIDC token cache with mutex on all locations

### DIFF
--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -129,20 +129,12 @@ func (c *thalassaCloudClient) configureAuth() error {
 		if c.oidcConfig == nil {
 			return ErrMissingOIDCConfig
 		}
-		// For each request, ensure token is valid or refresh it.
 		c.resty.OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
-			if c.oidcToken == nil || !c.oidcToken.Valid() {
-				ctx := req.Context()
-				if c.allowInsecureOIDC || c.rootCAs != nil {
-					ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClientWithTLS())
-				}
-				tok, err := c.oidcConfig.Token(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to fetch OIDC token: %w", err)
-				}
-				c.oidcToken = tok
+			accessToken, err := c.ensureOIDCClientCredentialsToken(req.Context())
+			if err != nil {
+				return err
 			}
-			req.SetAuthToken(c.oidcToken.AccessToken)
+			req.SetAuthToken(accessToken)
 			return nil
 		})
 
@@ -151,10 +143,11 @@ func (c *thalassaCloudClient) configureAuth() error {
 			return ErrOIDCTokenExchangeConfig
 		}
 		c.resty.OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
-			if err := c.ensureOIDCTokenExchange(req.Context()); err != nil {
+			accessToken, err := c.ensureOIDCTokenExchange(req.Context())
+			if err != nil {
 				return err
 			}
-			req.SetAuthToken(c.oidcToken.AccessToken)
+			req.SetAuthToken(accessToken)
 			return nil
 		})
 
@@ -182,18 +175,35 @@ func (c *thalassaCloudClient) configureAuth() error {
 	return nil
 }
 
-func (c *thalassaCloudClient) ensureOIDCTokenExchange(ctx context.Context) error {
-	c.oidcTokenExchangeMu.Lock()
-	defer c.oidcTokenExchangeMu.Unlock()
+func (c *thalassaCloudClient) ensureOIDCClientCredentialsToken(ctx context.Context) (string, error) {
+	c.oidcTokenMu.Lock()
+	defer c.oidcTokenMu.Unlock()
 	if c.oidcToken != nil && c.oidcToken.Valid() {
-		return nil
+		return c.oidcToken.AccessToken, nil
+	}
+	if c.allowInsecureOIDC || c.rootCAs != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClientWithTLS())
+	}
+	tok, err := c.oidcConfig.Token(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch OIDC token: %w", err)
+	}
+	c.oidcToken = tok
+	return tok.AccessToken, nil
+}
+
+func (c *thalassaCloudClient) ensureOIDCTokenExchange(ctx context.Context) (string, error) {
+	c.oidcTokenMu.Lock()
+	defer c.oidcTokenMu.Unlock()
+	if c.oidcToken != nil && c.oidcToken.Valid() {
+		return c.oidcToken.AccessToken, nil
 	}
 	tok, err := c.fetchOIDCTokenExchange(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	c.oidcToken = tok
-	return nil
+	return tok.AccessToken, nil
 }
 
 func (c *thalassaCloudClient) tokenExchangeHTTPClient() *http.Client {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -131,8 +131,8 @@ type thalassaCloudClient struct {
 	allowInsecureOIDC bool
 
 	// OIDC token exchange (RFC 8693-style) for IdP JWT → Thalassa bearer token.
-	oidcTokenExchange   *OIDCTokenExchangeConfig
-	oidcTokenExchangeMu sync.Mutex
+	oidcTokenExchange *OIDCTokenExchangeConfig
+	oidcTokenMu        sync.Mutex
 
 	// Personal Access Token.
 	personalToken string
@@ -176,6 +176,8 @@ func (c *thalassaCloudClient) SetOrganisation(organisation string) {
 func (c *thalassaCloudClient) GetAuthToken() string {
 	switch c.authType {
 	case AuthOIDC, AuthOIDCTokenExchange:
+		c.oidcTokenMu.Lock()
+		defer c.oidcTokenMu.Unlock()
 		if c.oidcToken != nil && c.oidcToken.Valid() {
 			return c.oidcToken.AccessToken
 		}


### PR DESCRIPTION
AuthOIDC read and wrote c.oidcToken without locking while token exchange already used a mutex, causing data races under concurrent requests. Route client-credentials refresh through the same lock and return the access token so callers never read the cache after unlock.