### PR TITLE
fix(client): return token from GetAuthToken with TokenAuth

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -175,6 +175,10 @@ func (c *thalassaCloudClient) SetOrganisation(organisation string) {
 
 func (c *thalassaCloudClient) GetAuthToken() string {
 	switch c.authType {
+	case AuthToken:
+		if c.oidcToken != nil && c.oidcToken.Valid() {
+			return c.oidcToken.AccessToken
+		}
 	case AuthOIDC, AuthOIDCTokenExchange:
 		c.oidcTokenMu.Lock()
 		defer c.oidcTokenMu.Unlock()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -520,6 +520,14 @@ func TestClientGetAuthToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test-token", client.GetAuthToken())
 
+	// Test with bearer token (WithToken)
+	client, err = NewClient(
+		WithBaseURL(server.URL),
+		WithToken("bearer-token"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "bearer-token", client.GetAuthToken())
+
 	// Test with no auth
 	client, err = NewClient(
 		WithBaseURL(server.URL),
@@ -618,6 +626,13 @@ func TestClientDialWebsocket(t *testing.T) {
 				WithAuthPersonalToken("test-token"),
 			},
 			wantAuthHeader: "Token test-token",
+		},
+		{
+			name: "bearer token via WithToken",
+			options: []Option{
+				WithToken("bearer-token"),
+			},
+			wantAuthHeader: "Token bearer-token",
 		},
 		{
 			name: "organization header",


### PR DESCRIPTION
AuthToken was missing from the GetAuthToken switch, so DialWebsocket sent an empty Authorization header when using WithToken.