### PR TITLE
fix(iaas): send snapshot policy ttl as string

### DIFF
--- a/iaas/snapshots.go
+++ b/iaas/snapshots.go
@@ -2,6 +2,7 @@ package iaas
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -535,6 +536,17 @@ type CreateSnapshotPolicyRequest struct {
 	Target SnapshotPolicyTarget `json:"target"`
 }
 
+// MarshalJSON encodes Ttl as a duration string such as "168h0m0s". The API
+// expects a string for this field, whereas the default encoding of
+// time.Duration is an integer number of nanoseconds.
+func (r CreateSnapshotPolicyRequest) MarshalJSON() ([]byte, error) {
+	type alias CreateSnapshotPolicyRequest
+	return json.Marshal(struct {
+		alias
+		Ttl string `json:"ttl"`
+	}{alias(r), r.Ttl.String()})
+}
+
 type UpdateSnapshotPolicyRequest struct {
 	// Name is the name of the snapshot policy. Must be unique within the organisation.
 	// The name is used for identification and display purposes.
@@ -563,4 +575,15 @@ type UpdateSnapshotPolicyRequest struct {
 	Timezone string `json:"timezone"`
 	// Target is the target of the snapshot policy
 	Target SnapshotPolicyTarget `json:"target"`
+}
+
+// MarshalJSON encodes Ttl as a duration string such as "168h0m0s". The API
+// expects a string for this field, whereas the default encoding of
+// time.Duration is an integer number of nanoseconds.
+func (r UpdateSnapshotPolicyRequest) MarshalJSON() ([]byte, error) {
+	type alias UpdateSnapshotPolicyRequest
+	return json.Marshal(struct {
+		alias
+		Ttl string `json:"ttl"`
+	}{alias(r), r.Ttl.String()})
 }

--- a/iaas/snapshots_test.go
+++ b/iaas/snapshots_test.go
@@ -1,0 +1,72 @@
+package iaas
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotPolicyRequest_TtlJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		ttl  time.Duration
+		want string
+	}{
+		{name: "one week", ttl: 168 * time.Hour, want: "168h0m0s"},
+		{name: "one day", ttl: 24 * time.Hour, want: "24h0m0s"},
+		{name: "sub hour", ttl: 90 * time.Minute, want: "1h30m0s"},
+		{name: "zero", ttl: 0, want: "0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			create, err := json.Marshal(CreateSnapshotPolicyRequest{Ttl: tt.ttl})
+			require.NoError(t, err)
+			var gotCreate map[string]any
+			require.NoError(t, json.Unmarshal(create, &gotCreate))
+			assert.Equal(t, tt.want, gotCreate["ttl"])
+
+			update, err := json.Marshal(UpdateSnapshotPolicyRequest{Ttl: tt.ttl})
+			require.NoError(t, err)
+			var gotUpdate map[string]any
+			require.NoError(t, json.Unmarshal(update, &gotUpdate))
+			assert.Equal(t, tt.want, gotUpdate["ttl"])
+		})
+	}
+}
+
+func TestCreateSnapshotPolicyRequest_JSONKeepsOtherFields(t *testing.T) {
+	keepCount := 10
+	req := CreateSnapshotPolicyRequest{
+		Name:        "daily",
+		Description: "Daily snapshots",
+		Region:      "nl-01",
+		Ttl:         168 * time.Hour,
+		KeepCount:   &keepCount,
+		Enabled:     true,
+		Schedule:    "0 3 * * *",
+		Timezone:    "Europe/Amsterdam",
+		Target: SnapshotPolicyTarget{
+			Type:             SnapshotPolicyTargetTypeExplicit,
+			VolumeIdentities: []string{"v-abc"},
+		},
+	}
+
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.Equal(t, "daily", got["name"])
+	assert.Equal(t, "Daily snapshots", got["description"])
+	assert.Equal(t, "nl-01", got["region"])
+	assert.Equal(t, "168h0m0s", got["ttl"])
+	assert.Equal(t, float64(10), got["keepCount"])
+	assert.Equal(t, true, got["enabled"])
+	assert.Equal(t, "0 3 * * *", got["schedule"])
+	assert.Equal(t, "Europe/Amsterdam", got["timezone"])
+	assert.NotNil(t, got["target"])
+}


### PR DESCRIPTION
`Ttl` is a `time.Duration` on the create and update requests, which `encoding/json` serialises as nanoseconds. The API expects a duration string, so every create and update fails with:

    json: cannot unmarshal number into Go struct field .ttl of type string

Adds `MarshalJSON` to both request types emitting `"168h0m0s"`. The field stays a `time.Duration`, so callers need no change. Reads are untouched: the API returns a number there and consumers already call `Ttl.String()`.

Verified by building the Terraform provider against this branch and creating a policy against the live API. Same config fails on v0.35.3.